### PR TITLE
Make logging offences outside of the PR diff optional

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -10,6 +10,9 @@ inputs:
   gem_versions:
     description: Gem versions to install
     default: rubocop:1.54.1 rubocop-rails:2.20.2 rubocop-rspec:2.22.0
+  outside_diff:
+    description: Log offences found outside of PR diff
+    default: "true"
   rubocop_arguments:
     description: Arguments passed to rubocop cli
     default: ""
@@ -21,4 +24,5 @@ runs:
       env:
         FAILURE_EXIT_CODE: ${{ inputs.failure_exit_code }}
         GITHUB_TOKEN: ${{ inputs.github_token }}
+        OUTSIDE_DIFF: ${{ inputs.outside_diff }}
         RUBOCOP_GEM_VERSIONS: ${{ inputs.gem_versions }}

--- a/rubocop.rb
+++ b/rubocop.rb
@@ -176,7 +176,9 @@ if offences_outside_diff.any?
   else
     puts "Commenting on pull request with offenses found outside the diff"
 
-    Github.post!("/repos/#{owner_and_repository}/issues/#{pr_number}/comments", body: body)
+    if ENV.fetch("OUTSIDE_DIFF", "true") == "true"
+      Github.post!("/repos/#{owner_and_repository}/issues/#{pr_number}/comments", body: body)
+    end
   end
 elsif existing_separate_comment
   existing_comment_id = existing_separate_comment.fetch("id")


### PR DESCRIPTION
Including rubocop offences found that were outside of the work shown in the PR can be distracting when working with legacy code.

This makes logging these offences optional.